### PR TITLE
BUGFIX #10, bad importing on build_ext

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ from distutils.core import setup#, Command
 #from distutils.core import Distribution as _Distribution
 from distutils.core import Extension# as _Extension
 #from distutils.dir_util import mkpath
-from distutils.command.build_ext import build_ext as _build_ext
+from distutils.command.build_ext import build_ext #as _build_ext
 #from distutils.command.bdist_rpm import bdist_rpm as _bdist_rpm
 #from distutils.errors import CompileError, LinkError, DistutilsPlatformError
 


### PR DESCRIPTION
It was importing
from distutils.command.build_ext import build_ext as _build_ext
but later it was expecting build_ext.